### PR TITLE
Added support for MicroWorld-eScan Antivirus for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ engines simultaneously. It uses, with the only exception of ClamAV, the
 command line AV scanners and extracts the malware names from the output
 of the command line tools (for ClamAV it uses the https://code.google.com/p/pyclamd/ extension).
 
-It supports a total of 15 AV engines. The list of currently supported
+It supports a total of 16 AV engines. The list of currently supported
 engines is the following:
 
    * ClamAV (Ultra-fast, using the daemon)
@@ -24,6 +24,7 @@ engines is the following:
    * F-Secure (Fast)
    * Kaspersky (Fast, only tested under MacOSX)
    * Zoner Antivirus (Ultra-fast)
+   * MicroWorld-eScan (Fast)
 
 This tool have been tested only under Linux. However, it should work equally
 in other Unix based operating systems as well as in Windows as long as the

--- a/multiav/config.cfg
+++ b/multiav/config.cfg
@@ -41,6 +41,10 @@ ARGUMENTS=
 PATH=/usr/local/uvscan
 ARGUMENTS=--ASCII --ANALYZE --MANALYZE  --MACRO-HEURISTICS --RECURSIVE --UNZIP 
 
+[MicroWorld-eScan]
+PATH=/usr/bin/escan
+ARGUMENTS=--log-only --recursion --no-symlink --pack --archives --mails --heuristic --log-infections
+
 # Ikarus is supported in Linux running it with wine (and it works great)
 [Ikarus]
 PATH=/usr/bin/wine


### PR DESCRIPTION
I have added support for MicroWorld-eScan Antivirus for Linux increasing the number of supported antivirus scanners to 16. I followed most of the Contributing guidelines; however, in its current state the forked original multiav repo does not pass flake8 mostly due to whitespace, long lines, and W602 deprecated form of raising exception - When raising an exception, use "raise ValueError('message')" in  some of the code under the web directory. 

I wanted to keep the code changes minimal while adding capability for an additional antivirus scanner. I have tested that the changes work; however, following 5. under the Contributing guidelines does not work even before any changes are made. It is possible that my environment is missing something so if more testing is required to accept the pull request then I am willing to work on that. I may just need to understand your development environment better. Thanks!
