### PR TITLE
Added support for CYREN Antivirus Commandline Scanner for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ engines simultaneously. It uses, with the only exception of ClamAV, the
 command line AV scanners and extracts the malware names from the output
 of the command line tools (for ClamAV it uses the https://code.google.com/p/pyclamd/ extension).
 
-It supports a total of 16 AV engines. The list of currently supported
+It supports a total of 17 AV engines. The list of currently supported
 engines is the following:
 
    * ClamAV (Ultra-fast, using the daemon)
@@ -25,6 +25,7 @@ engines is the following:
    * Kaspersky (Fast, only tested under MacOSX)
    * Zoner Antivirus (Ultra-fast)
    * MicroWorld-eScan (Fast)
+   * Cyren (Ultra-fast)
 
 This tool have been tested only under Linux. However, it should work equally
 in other Unix based operating systems as well as in Windows as long as the

--- a/multiav/config.cfg
+++ b/multiav/config.cfg
@@ -64,3 +64,7 @@ DISABLED=1
 [ZAV]
 PATH=/usr/bin/zavcli
 ARGUMENTS=--no-show=clean
+
+[Cyren]
+PATH=/usr/bin/aiscan
+ARGUMENTS=--nombr --noboot --nomem --nobasicmem --noadvancedmem --limit-memory=10 --ads --heur-high --pua --archive=10


### PR DESCRIPTION
I have added support for CYREN Commandline Scanner for Linux increasing the number of supported antivirus scanners to 17. The CYREN product is also known as CSAM for Linux or COMMAND ANTI-MALWARE. 

Please let me know if you require any changes or additional information. Thanks!
