### PR TITLE
Added support for Kaspersky Security for Linux Mail Server (KLMS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ engines is the following:
    * McAfee (Very slow, only enabled when running all the engines)
    * Ikarus (Medium, using Wine in Linux/Unix)
    * F-Secure (Fast)
-   * Kaspersky (Fast, only tested under MacOSX)
+   * Kaspersky (Fast, tested under MacOSX & Linux)
    * Zoner Antivirus (Ultra-fast)
    * MicroWorld-eScan (Fast)
    * Cyren (Ultra-fast)

--- a/multiav/config.cfg
+++ b/multiav/config.cfg
@@ -55,11 +55,17 @@ DISABLED=1
 PATH=/usr/bin/fsav
 ARGUMENTS=--action1=none --action2=none
 
-[Kaspersky]
+#[Kaspersky]
 # Works at least in MacOSX
-PATH=/usr/bin/kav
-ARGUMENTS=scan $FILE -i0 -fa
-DISABLED=1
+#PATH=/usr/bin/kav
+#ARGUMENTS=scan $FILE -i0 -fa
+#DISABLED=1
+
+# Kaspersky Security for Linux Mail Server is supported
+[Kaspersky]
+# KLMS works in Linux
+PATH=/usr/local/bin/kavscanner
+ARGUMENTS=-i0
 
 [ZAV]
 PATH=/usr/bin/zavcli

--- a/multiav/core.py
+++ b/multiav/core.py
@@ -48,9 +48,7 @@
 #   * MicroWorld-eScan (Fast)
 #   * Cyren (Fast)
 #
-# Support for the following AV engines is limited to MacOSX and Windows:
-#
-#   * Kaspersky
+# Support for the Kaspersky AV engine includes MacOSX, Windows, and Linux
 #
 # Features:
 #
@@ -181,14 +179,50 @@ class CKasperskyScanner(CAvScanner):
     # This is why...
     self.speed = AV_SPEED_FAST
     self.pattern = r"\d+-\d+-\d+ \d+:\d+:\d+\W(.*)\Wdetected\W(.*)"
+    self.pattern2 = '(.*)(INFECTED|SUSPICION UDS:|SUSPICION HEUR:|WARNING HEUR:)(.*)'    
 
   def build_cmd(self, path):
     parser = self.cfg_parser
     scan_path = parser.get(self.name, "PATH")
     scan_args = parser.get(self.name, "ARGUMENTS")
     args = [scan_path]
-    args.extend(scan_args.replace("$FILE", path).split(" "))
+    ver = os.path.basename(scan_path)
+    if ver == "kavscanner":
+        args.extend(scan_args.split(" "))
+        args.append(path)      
+    elif ver == "kav":
+        args.extend(scan_args.replace("$FILE", path).split(" "))
     return args
+
+  def scan(self, path):
+    if self.pattern is None:
+        Exception("Not implemented")
+
+    try:
+        cmd = self.build_cmd(path)
+    except: # There is no entry in the *.cfg file for this AV engine?
+        pass
+
+    try: # stderr=devnull because kavscanner writes socket info
+        with open(os.devnull, "w") as devnull:      
+            output = check_output(cmd, stderr=devnull)
+
+    except CalledProcessError as e:
+        output = e.output
+    ver = os.path.basename(cmd.pop(0))
+    if ver == "kavscanner":
+        self.file_index = 0
+        self.malware_index = 2
+        matches = re.findall(self.pattern2, output, re.IGNORECASE|re.MULTILINE)
+        for match in matches:
+          self.results[match[self.file_index].split('\x08')[0].rstrip()] =\
+              match[self.malware_index].lstrip().rstrip()
+    elif ver == "kav":
+        matches = re.findall(self.pattern, output, re.IGNORECASE|re.MULTILINE)
+        for match in matches:
+          self.results[match[self.file_index]] = match[self.malware_index]
+
+    return len(self.results) > 0
 
 #-----------------------------------------------------------------------
 class CClamScanner(CAvScanner):


### PR DESCRIPTION
I have added support for the Anti-virus command line file scanner that is included in the Kaspersky Security for Linux Mail Server (KLMS) software package. 

The added support will return the following detections: INFECTED, SUSPICION UDS, SUSPICION HEUR, WARNING HEUR

Kaspersky is now supported on Linux when using KLMS.

Please let me know if you require any changes or additional information. Thanks!
