### PR TITLE
Added support for Quick Heal Antivirus for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ engines simultaneously. It uses, with the only exception of ClamAV, the
 command line AV scanners and extracts the malware names from the output
 of the command line tools (for ClamAV it uses the https://code.google.com/p/pyclamd/ extension).
 
-It supports a total of 17 AV engines. The list of currently supported
+It supports a total of 18 AV engines. The list of currently supported
 engines is the following:
 
    * ClamAV (Ultra-fast, using the daemon)
@@ -26,6 +26,7 @@ engines is the following:
    * Zoner Antivirus (Ultra-fast)
    * MicroWorld-eScan (Fast)
    * Cyren (Ultra-fast)
+   * QuickHeal (Fast)
 
 This tool have been tested only under Linux. However, it should work equally
 in other Unix based operating systems as well as in Windows as long as the

--- a/multiav/config.cfg
+++ b/multiav/config.cfg
@@ -68,3 +68,7 @@ ARGUMENTS=--no-show=clean
 [Cyren]
 PATH=/usr/bin/aiscan
 ARGUMENTS=--nombr --noboot --nomem --nobasicmem --noadvancedmem --limit-memory=10 --ads --heur-high --pua --archive=10
+
+[QuickHeal]
+PATH=/usr/bin/qhscan
+ARGUMENTS=$FILE -DNAScan -WARE -MIME -ARCHIVE -PACKED


### PR DESCRIPTION
I have added support for Quick Heal Antivirus for Linux increasing the number of supported antivirus scanners to 18. The README, config.cfg, and core.py files have been updated.

Please let me know if you require any changes or additional information. Thanks!
