### PR TITLE
Make runserver.py executable from /scripts directory

### DIFF
--- a/multiav/scripts/runserver.py
+++ b/multiav/scripts/runserver.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+import os, sys
+os.chdir('../')
+sys.path.append('../')
+
 from multiav.webapi import app
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a small changes to make sure the user can execute the server directly from where it is located (/scripts directory).