### PR TITLE
fix problem where the running list could have a running scanner remov…

### DIFF
--- a/multiav/core.py
+++ b/multiav/core.py
@@ -563,14 +563,12 @@ class CMultiAV:
         p.start()
         running.append(p)
 
-      i = 0
+      newrunning = []
       for p in list(running):
         p.join(0.1)
-        if not p.is_alive():
-          del running[i]
-          i -= 1
-        else:
-          i += 1
+        if p.is_alive():
+          newrunning.append(p)
+      running = newrunning
 
     results = {}
     while not q.empty():


### PR DESCRIPTION
This change fixes an issue in the running state list where running processes can be removed instead of ones that are stopped, which can cause the scan to prematurely end. 

Here is the test code I wrote to diagnose it:

```
def original(list):
  i=0
  for entry in list:
    if not entry['running']:
      del list[i]
      i-=1
    else:
      i+=1
  return list

def new(list):
  newlist=[]
  for entry in list:
    if entry['running']:
      newlist.append(entry)
  return newlist
```


```
>>> original([ {'running':True} , {'running':False } , {'running':True}, {'running':False }])
[{'running': True}, {'running': False}]
>>> new([ {'running':True} , {'running':False } , {'running':True}, {'running':False }])
[{'running': True}, {'running': True}]
```