### PR TITLE
fix a bug 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,29 @@ engines simultaneously. It uses, with the only exception of ClamAV, the
 command line AV scanners and extracts the malware names from the output
 of the command line tools (for ClamAV it uses the https://code.google.com/p/pyclamd/ extension).
 
-It supports a total of 18 AV engines. The list of currently supported
+It supports a total of 19 AV engines. The list of currently supported
 engines is the following:
 
    * ClamAV (Ultra-fast, using the daemon)
-   * F-Prot (Ultra-fast)
-   * Comodo (Fast)
-   * BitDefender (Medium)
-   * ESET (Slow)
-   * Avira (Slow)
-   * Sophos (Medium)
    * Avast (Ultra-fast, using the daemon)
    * AVG (Ultra-fast, using the daemon)
+   * Cyren (Ultra-fast)
+   * F-Prot (Ultra-fast)
+   * Zoner Antivirus (Ultra-fast)
+   * Comodo (Fast)
+   * MicroWorld-eScan (Fast)
+   * Kaspersky (Fast, tested under MacOSX & Linux)
+   * TrendMicro (Fast, tested under centOS6&7)
+   * F-Secure (Fast)
+   * QuickHeal (Fast)
+   * BitDefender (Medium)
+   * Ikarus (Medium, using Wine in Linux/Unix)
+   * Sophos (Medium)
+   * ESET (Slow)
+   * Avira (Slow)
    * DrWeb (Slow)
    * McAfee (Very slow, only enabled when running all the engines)
-   * Ikarus (Medium, using Wine in Linux/Unix)
-   * F-Secure (Fast)
-   * Kaspersky (Fast, tested under MacOSX & Linux)
-   * Zoner Antivirus (Ultra-fast)
-   * MicroWorld-eScan (Fast)
-   * Cyren (Ultra-fast)
-   * QuickHeal (Fast)
-
+   
 This tool have been tested only under Linux. However, it should work equally
 in other Unix based operating systems as well as in Windows as long as the
 output from the AV command line utilities maintains the same format.

--- a/multiav/core.py
+++ b/multiav/core.py
@@ -151,12 +151,17 @@ class CTrendmicroScanner(CAvScanner):
     logdir = '/var/log/TrendMicro/SProtectLinux'
     logfile = logdir+'/Virus.' + time.strftime('%Y%m%d') + '.0001'
     call(cmd)
-
-    with open(logfile, 'r') as log:
-      output = log.read()
-    reset = open(logfile, 'wb') #Clear the log file
-    reset.close()
-
+    
+    while True:
+      ps_strs = ps_str.strip().split('\n')
+      if len(ps_strs) > 2:
+        time.sleep(0.5)
+      else:
+        with open(logfile, 'rb') as log:
+          output = log.read()
+        break
+    call(['rm','-rf','/var/log/TrendMicro/SProtectLinux']) #Clear the log
+	
     matches1 = re.findall(self.pattern1, output, re.IGNORECASE|re.MULTILINE)
     matches2 = re.findall(self.pattern2, output, re.IGNORECASE|re.MULTILINE)
     for i in range(len(matches1)):

--- a/multiav/core.py
+++ b/multiav/core.py
@@ -152,7 +152,9 @@ class CTrendmicroScanner(CAvScanner):
     logfile = logdir+'/Virus.' + time.strftime('%Y%m%d') + '.0001'
     call(cmd)
     
+    #Monitor trendmicro's process and read the log only after the end of the scan
     while True:
+      ps_str = os.popen('ps ax | grep splx_manual_scan').read()
       ps_strs = ps_str.strip().split('\n')
       if len(ps_strs) > 2:
         time.sleep(0.5)


### PR DESCRIPTION
I found that sometimes the program will read the log before the scan
ends. It will cause the program can not read the full scan results.So I
let the program to monitor the process of scanning which can ensure the
program reads the log only after the scan ends.